### PR TITLE
Fix command for inserts from select

### DIFF
--- a/Sources/ClickHouseNIO/ChannelHandler.swift
+++ b/Sources/ClickHouseNIO/ChannelHandler.swift
@@ -188,7 +188,6 @@ final class ClickHouseChannelHandler: ChannelDuplexHandler {
                 return
             }
             if case .data(_) = response {
-                print(response)
                 // if command is used we are not interested in the data...
                 return
             }

--- a/Sources/ClickHouseNIO/ChannelHandler.swift
+++ b/Sources/ClickHouseNIO/ChannelHandler.swift
@@ -192,7 +192,6 @@ final class ClickHouseChannelHandler: ChannelDuplexHandler {
                 return
             }
             guard case .endOfStream = response else {
-                print(response)
                 context.fireErrorCaught(ClickHouseError.expectedEndOfStream)
                 return
             }

--- a/Sources/ClickHouseNIO/ChannelHandler.swift
+++ b/Sources/ClickHouseNIO/ChannelHandler.swift
@@ -180,11 +180,20 @@ final class ClickHouseChannelHandler: ChannelDuplexHandler {
             return
             
         case .awaitingQueryConfirmation:
+            if case .profileInfo(_) = response {
+                return
+            }
             if case .progress(_) = response {
                 // For DROP table commands, clickhouse server 20.x sends also a progress message
                 return
             }
+            if case .data(_) = response {
+                print(response)
+                // if command is used we are not interested in the data...
+                return
+            }
             guard case .endOfStream = response else {
+                print(response)
                 context.fireErrorCaught(ClickHouseError.expectedEndOfStream)
                 return
             }

--- a/Tests/ClickHouseNIOTests/ClickhouseNIOTests.swift
+++ b/Tests/ClickHouseNIOTests/ClickhouseNIOTests.swift
@@ -171,4 +171,36 @@ ENGINE = MergeTree() PRIMARY KEY stationid ORDER BY stationid
             XCTAssertEqual(id, [1, 2, 3])
         }.wait()
     }
+    
+    
+    func testCommandForInsertsFromSelectWorks() {
+        try! conn.connection.command(sql: "DROP TABLE IF EXISTS test").wait()
+        
+        let sql = """
+CREATE TABLE test
+(
+    stationid Int32,
+    timestamp Int64,
+    value Float32,
+    varstring String,
+    fixstring FixedString(2)
+)
+ENGINE = MergeTree() PRIMARY KEY stationid ORDER BY stationid
+"""
+        try! conn.connection.command(sql: sql).wait()
+        let count = 110
+        
+        let data = [
+            ClickHouseColumn("stationid", (0..<count).map{Int32($0)}),
+            ClickHouseColumn("timestamp", (0..<count).map{Int64($0)}),
+            ClickHouseColumn("value", (0..<count).map{Float($0)}),
+            ClickHouseColumn("varstring", (0..<count).map{"\($0)"}),
+            ClickHouseColumn("fixstring", (0..<count).map{"\($0)"})
+        ]
+        
+        try! conn.connection.insert(into: "test", data: data).wait()
+        
+        // insert again, but this time via a select from the database
+        try! conn.connection.command(sql: "Insert into test Select * from test").wait()
+    }
 }

--- a/Tests/ClickHouseNIOTests/ClickhouseNIOTests.swift
+++ b/Tests/ClickHouseNIOTests/ClickhouseNIOTests.swift
@@ -71,13 +71,13 @@ final class ClickHouseNIOTests: XCTestCase {
         let fixedLength = 7
         
         let sql = """
-        CREATE TABLE test
-        (
-        id String,
-        string FixedString(\(fixedLength))
-        )
-        ENGINE = MergeTree() PRIMARY KEY id ORDER BY id
-        """
+            CREATE TABLE test
+            (
+            id String,
+            string FixedString(\(fixedLength))
+            )
+            ENGINE = MergeTree() PRIMARY KEY id ORDER BY id
+            """
         try! conn.connection.command(sql: sql).wait()
         
         let data = [
@@ -104,16 +104,16 @@ final class ClickHouseNIOTests: XCTestCase {
         try! conn.connection.command(sql: "DROP TABLE IF EXISTS test").wait()
         
         let sql = """
-CREATE TABLE test
-(
-    stationid Int32,
-    timestamp Int64,
-    value Float32,
-    varstring String,
-    fixstring FixedString(2)
-)
-ENGINE = MergeTree() PRIMARY KEY stationid ORDER BY stationid
-"""
+            CREATE TABLE test
+            (
+                stationid Int32,
+                timestamp Int64,
+                value Float32,
+                varstring String,
+                fixstring FixedString(2)
+            )
+            ENGINE = MergeTree() PRIMARY KEY stationid ORDER BY stationid
+            """
         try! conn.connection.command(sql: sql).wait()
         let count = 110
         

--- a/Tests/ClickHouseNIOTests/ClickhouseNIOTests.swift
+++ b/Tests/ClickHouseNIOTests/ClickhouseNIOTests.swift
@@ -71,13 +71,13 @@ final class ClickHouseNIOTests: XCTestCase {
         let fixedLength = 7
         
         let sql = """
-CREATE TABLE test
-(
-id String,
-string FixedString(\(fixedLength))
-)
-ENGINE = MergeTree() PRIMARY KEY id ORDER BY id
-"""
+        CREATE TABLE test
+        (
+        id String,
+        string FixedString(\(fixedLength))
+        )
+        ENGINE = MergeTree() PRIMARY KEY id ORDER BY id
+        """
         try! conn.connection.command(sql: sql).wait()
         
         let data = [
@@ -177,16 +177,16 @@ ENGINE = MergeTree() PRIMARY KEY stationid ORDER BY stationid
         try! conn.connection.command(sql: "DROP TABLE IF EXISTS test").wait()
         
         let sql = """
-CREATE TABLE test
-(
-    stationid Int32,
-    timestamp Int64,
-    value Float32,
-    varstring String,
-    fixstring FixedString(2)
-)
-ENGINE = MergeTree() PRIMARY KEY stationid ORDER BY stationid
-"""
+            CREATE TABLE test
+            (
+                stationid Int32,
+                timestamp Int64,
+                value Float32,
+                varstring String,
+                fixstring FixedString(2)
+            )
+            ENGINE = MergeTree() PRIMARY KEY stationid ORDER BY stationid
+            """
         try! conn.connection.command(sql: sql).wait()
         let count = 110
         


### PR DESCRIPTION
Executing a command like
```
INSERT INTO db.table SELECT * FROM db.table 
```
failed with the .query() and the .command() operations. 

This fix simply neglects returned data when using .command(sql: String).