### PR TITLE
Support for more ClickHouse-Types

### DIFF
--- a/Sources/ClickHouseNIO/ClickHouseArray.swift
+++ b/Sources/ClickHouseNIO/ClickHouseArray.swift
@@ -64,7 +64,7 @@ extension Array: ClickHouseDataTypeArray where Element: ClickHouseDataType {
 }
 
 /// Container for the Column-Metadata
-public enum ClickHouseColumnMetadata: Codable {
+public enum ClickHouseColumnMetadata {
     case fixedStringLength(Int)
     case dateTimeTimeZone(String?)
     case dateTime64Precision(Int, String?)
@@ -255,26 +255,26 @@ public indirect enum ClickHouseTypeName {
             return "Date"
         case .date32:
             return "Date32"
-        case .dateTime(let timezone):
-            guard case let .dateTimeTimeZone(timezone) = timezone else {
-                fatalError("dateTime should have dateTimeTimeZone-enum for column-metadate, not\(timezone)")
+        case .dateTime(let timezoneData):
+            guard case let .dateTimeTimeZone(timezoneData) = timezoneData else {
+                fatalError("dateTime should have dateTimeTimeZone-enum for column-metadata, not\(timezoneData)")
             }
-            if let timezone = timezone {
-                return "DateTime64(\(timezone))"
+            if let timezoneData = timezoneData {
+                return "DateTime64(\(timezoneData))"
 
             }
             return "DateTime"
         case .dateTime64(let precision):
-            guard case let .dateTime64Precision(precision, timezone) = precision else {
-                fatalError("dateTime64 should have dateTime64precision-enum for column-metadate, not\(timezone)")
+            guard case let .dateTime64Precision(precision, timezoneData) = precision else {
+                fatalError("dateTime64 should have dateTime64precision-enum for column-metadata, not\(precision)")
             }
-            if let timezone = timezone {
-                return "DateTime64(\(precision), \(timezone))"
+            if let timezoneData = timezoneData {
+                return "DateTime64(\(precision), \(timezoneData))"
             }
             return "DateTime64(\(precision))"
         case .enum16(let mapping):
             guard case let .enum16Map(mapping) = mapping else {
-                fatalError("enum16 should have enum16Map-enum for column-metadate, not\(timezone)")
+                fatalError("enum16 should have enum16Map-enum for column-metadata, not \(mapping)")
             }
             let hm =             mapping.map({
                 "'\($0.key)'=\($0.value)"
@@ -286,7 +286,7 @@ public indirect enum ClickHouseTypeName {
             return "Enum16(\(hm))"
         case .enum8(let mapping):
             guard case let .enum8Map(mapping) = mapping else {
-                fatalError("enum8 should have enum8Map-enum for column-metadate, not\(timezone)")
+                fatalError("enum8 should have enum8Map-enum for column-metadata, not\(mapping)")
             }
             // mapping.map({
             //     "'\($0.key)'=\($0.value)"
@@ -559,7 +559,7 @@ public struct ClickHouseDateTime64: ClickHouseDataType, CustomStringConvertible 
     public static func readFrom(buffer: inout ByteBuffer, numRows: Int, columnMetadata: ClickHouseColumnMetadata?) -> [ClickHouseDateTime64]? {
         guard let columnMetadata = columnMetadata,
         case let .dateTime64Precision(precision, _) = columnMetadata else {
-            fatalError("dateTime64 should have dateTime64precision-enum for column-metadate, not \(String(describing: columnMetadata))")
+            fatalError("dateTime64 should have dateTime64precision-enum for column-metadata, not \(String(describing: columnMetadata))")
         }
         guard let intergerArray: [Int64] = buffer.readIntegerArray(numRows: numRows) else {
             return nil
@@ -583,7 +583,7 @@ public struct ClickHouseDateTime64: ClickHouseDataType, CustomStringConvertible 
 
     public static func writeTo(buffer: inout ByteBuffer, array: [ClickHouseDateTime64], columnMetadata: ClickHouseColumnMetadata?) {
         guard let columnMetadata = columnMetadata, case let .dateTime64Precision(precision, _) = columnMetadata else {
-            fatalError("dateTime64 should have dateTime64precision-enum for column-metadate, not\(String(describing: columnMetadata))")
+            fatalError("dateTime64 should have dateTime64precision-enum for column-metadata, not\(String(describing: columnMetadata))")
         }
         let intergerArray = array.map({
             Int64($0.date.timeIntervalSince1970 * pow(10.0, Double(precision)))
@@ -659,7 +659,7 @@ public struct ClickHouseEnum8: ClickHouseDataType, CustomStringConvertible {
     public var word: String
     public static func readFrom(buffer: inout ByteBuffer, numRows: Int, columnMetadata: ClickHouseColumnMetadata?) -> [ClickHouseEnum8]? {
         guard case let .enum8Map(mapping) = columnMetadata! else {
-            fatalError("enum8 should have enum8Map-enum for column-metadate, not\(timezone)")
+            fatalError("enum8 should have enum8Map-enum for column-metadata, not \(String(describing: columnMetadata))")
         }
         let reversedEnumMapping = [Int8: String](uniqueKeysWithValues: zip(mapping.values, mapping.keys))
         guard let intergerArray: [Int8] = buffer.readIntegerArray(numRows: numRows) else {
@@ -678,7 +678,7 @@ public struct ClickHouseEnum8: ClickHouseDataType, CustomStringConvertible {
 
     public static func writeTo(buffer: inout ByteBuffer, array: [ClickHouseEnum8], columnMetadata: ClickHouseColumnMetadata?) {
         guard case let .enum8Map(mapping) = columnMetadata! else {
-            fatalError("enum8 should have enum8Map-enum for column-metadate, not\(timezone)")
+            fatalError("enum8 should have enum8Map-enum for column-metadata, not \(String(describing: columnMetadata))")
         }
         let intergerArray = array.map { mapping[$0.word]! }
         buffer.writeIntegerArray(intergerArray)
@@ -698,7 +698,7 @@ public struct ClickHouseEnum16: ClickHouseDataType, CustomStringConvertible {
     public var word: String
     public static func readFrom(buffer: inout ByteBuffer, numRows: Int, columnMetadata: ClickHouseColumnMetadata?) -> [ClickHouseEnum16]? {
         guard case let .enum16Map(mapping) = columnMetadata! else {
-            fatalError("enum16 should have enum16Map-enum for column-metadate, not\(timezone)")
+            fatalError("enum16 should have enum16Map-enum for column-metadata, not \(String(describing: columnMetadata))")
         }
         let reversedEnumMapping = [Int16: String](uniqueKeysWithValues: zip(mapping.values, mapping.keys))
         let intergerArray: [Int16]? = buffer.readIntegerArray(numRows: numRows)
@@ -717,7 +717,7 @@ public struct ClickHouseEnum16: ClickHouseDataType, CustomStringConvertible {
 
     public static func writeTo(buffer: inout ByteBuffer, array: [ClickHouseEnum16], columnMetadata: ClickHouseColumnMetadata?) {
         guard case let .enum16Map(mapping) = columnMetadata! else {
-            fatalError("enum16 should have enum16Map-enum for column-metadate, not\(timezone)")
+            fatalError("enum16 should have enum16Map-enum for column-metadata, not \(String(describing: columnMetadata))")
         }
         let intergerArray = array.map { mapping[$0.word]! }
         buffer.writeIntegerArray(intergerArray)

--- a/Sources/ClickHouseNIO/ClickHouseArray.swift
+++ b/Sources/ClickHouseNIO/ClickHouseArray.swift
@@ -31,7 +31,7 @@ public protocol ClickHouseDataTypeArray {
 
     func writeTo(buffer: inout ByteBuffer, type: ClickHouseTypeName, name: String)
 
-    static func readFrom(buffer: inout ByteBuffer, numRows: Int, fixedLength: ClickHouseColumnMetadata?) -> ClickHouseDataTypeArray?
+    static func readFrom(buffer: inout ByteBuffer, numRows: Int, columnMetadata: ClickHouseColumnMetadata?) -> ClickHouseDataTypeArray?
 }
 
 
@@ -47,21 +47,22 @@ extension Array: ClickHouseDataTypeArray where Element: ClickHouseDataType {
     }
 
     public func writeTo(buffer: inout ByteBuffer, type: ClickHouseTypeName, name: String) {
-        assert(type.string == Element.getClickHouseTypeName(fixedLength: type.fixedLength).string)
+        assert(type.string == Element.getClickHouseTypeName(columnMetadata: type.columnMetadata).string)
         buffer.writeClickHouseString(name)
         if type.string.hasPrefix("Enum") {
             buffer.writeClickHouseString(type.string.replacingOccurrences(of: "\": ", with: "' = ").replacingOccurrences(of: ", \"", with: ", '"))
         } else {
             buffer.writeClickHouseString(type.string)
         }
-        Element.writeTo(buffer: &buffer, array: self, fixedLength: type.fixedLength)
+        Element.writeTo(buffer: &buffer, array: self, columnMetadata: type.columnMetadata)
     }
 
-    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, fixedLength: ClickHouseColumnMetadata?) -> ClickHouseDataTypeArray? {
-        return Element.readFrom(buffer: &buffer, numRows: numRows, fixedLength: fixedLength)
+    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, columnMetadata: ClickHouseColumnMetadata?) -> ClickHouseDataTypeArray? {
+        return Element.readFrom(buffer: &buffer, numRows: numRows, columnMetadata: columnMetadata)
     }
 }
 
+/// Container for the Column-Metadata
 public enum ClickHouseColumnMetadata: Codable {
     case fixedStringLength(Int)
     case dateTimeTimeZone(String?)
@@ -138,18 +139,20 @@ public indirect enum ClickHouseTypeName {
             self = .array(subType)
         }
         else if type.starts(with: "Enum8(") {
-            let subTypeName = String(type.dropFirst("Enum8(".count).dropLast())
-            let s = "{" + subTypeName.replacingOccurrences(of: "' = ", with: "\" : ").replacingOccurrences(of: "'", with: "\"") + "}"
-            let da = s.data(using: .utf8)!
-            let su = (try? JSONDecoder().decode([String: Int8].self, from: da))!
-            self = .enum8(.enum8Map(su))
+            let columnMapping = String(type.dropFirst("Enum8(".count).dropLast())
+            guard let data = ("{" + columnMapping.replacingOccurrences(of: "' = ", with: "\" : ").replacingOccurrences(of: "'", with: "\"") + "}").data(using: .utf8),
+                let mapping = try? JSONDecoder().decode([String: Int8].self, from: data) else {
+                    return nil
+                }
+            self = .enum8(.enum8Map(mapping))
         }
         else if type.starts(with: "Enum16(") {
-            let subTypeName = String(type.dropFirst("Enum16(".count).dropLast())
-            let s = "{" + subTypeName.replacingOccurrences(of: "' = ", with: "\" : ").replacingOccurrences(of: "'", with: "\"") + "}"
-            let da = s.data(using: .utf8)!
-            let su = (try? JSONDecoder().decode([String: Int16].self, from: da))!
-            self = .enum16(.enum16Map(su))
+            let columnMapping = String(type.dropFirst("Enum16(".count).dropLast())
+            guard let data = ("{" + columnMapping.replacingOccurrences(of: "' = ", with: "\" : ").replacingOccurrences(of: "'", with: "\"") + "}").data(using: .utf8),
+                let mapping = try? JSONDecoder().decode([String: Int16].self, from: data) else {
+                    return nil
+                }
+            self = .enum16(.enum16Map(mapping))
         }
         else {
             switch type {
@@ -190,7 +193,7 @@ public indirect enum ClickHouseTypeName {
             }
         }
     }
-    public var fixedLength: ClickHouseColumnMetadata? {
+    public var columnMetadata: ClickHouseColumnMetadata? {
         switch self {
         case .fixedString(let len):
             return len
@@ -200,6 +203,10 @@ public indirect enum ClickHouseTypeName {
             return m
         case .enum16(let m):
             return m
+        case .array(let subtype):
+            return subtype.columnMetadata
+        case .nullable(let subtype):
+            return subtype.columnMetadata
         default:
             return nil
         }
@@ -403,7 +410,7 @@ public indirect enum ClickHouseTypeName {
             case .string:
                 return [String?].self
             case .array(_):
-                fatalError("no array in nullable")
+                fatalError("no array in nullable (for now)")
             case .boolean:
                 return [Bool?].self
             case .date:
@@ -427,30 +434,28 @@ public indirect enum ClickHouseTypeName {
 
 public protocol ClickHouseDataType {
     /// Used by ORM to determinte the type of a given array
-    static func getClickHouseTypeName(fixedLength: ClickHouseColumnMetadata?) -> ClickHouseTypeName
+    static func getClickHouseTypeName(columnMetadata: ClickHouseColumnMetadata?) -> ClickHouseTypeName
 
     /// Write an array of this type to a bytebuffer
-    static func writeTo(buffer: inout ByteBuffer, array: [Self], fixedLength: ClickHouseColumnMetadata?)
+    static func writeTo(buffer: inout ByteBuffer, array: [Self], columnMetadata: ClickHouseColumnMetadata?)
 
     /// Return nil for more data. Moved buffer forward if sucessfull
-    static func readFrom(buffer: inout ByteBuffer, numRows: Int, fixedLength: ClickHouseColumnMetadata?) -> [Self]?
+    static func readFrom(buffer: inout ByteBuffer, numRows: Int, columnMetadata: ClickHouseColumnMetadata?) -> [Self]?
 
     /// Default value. Used for nullable values
     static var clickhouseDefault: Self { get }
 }
 
+/// Struct for the Date32-ClickHouse-Type, has a date-field which is a swift-date
 public struct ClickHouseDate32: ClickHouseDataType, CustomStringConvertible {
-    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, fixedLength: ClickHouseColumnMetadata?) -> [ClickHouseDate32]? {
-        guard let a: [Int32] = buffer.readIntegerArray(numRows: numRows) else {
+    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, columnMetadata: ClickHouseColumnMetadata?) -> [ClickHouseDate32]? {
+        guard let intergerArray: [Int32] = buffer.readIntegerArray(numRows: numRows) else {
             return nil
         }
-        return a.map {
-            .init(date:
-                Date(timeIntervalSince1970: Double(24 * 3600 * Int($0)))
-            )
-        }
+        return intergerArray.map { .init(date: Date(timeIntervalSince1970: Double(24 * 3600 * Int($0)))) }
     }
 
+    /// constructs a ClickHouseDate32 with the given Date without changing anything
     public init(_ exact: Date) {
         self.date = exact
     }
@@ -459,18 +464,27 @@ public struct ClickHouseDate32: ClickHouseDataType, CustomStringConvertible {
         self.date = date
     }
 
+    /// constructs a ClickHouseDate32 for the given Date while setting the hour, minute and second to 0
+    /// if the setting fails, returns nil
+    public init?(flooring: Date) {
+        guard let date = Calendar.current.date(bySettingHour: 0, minute: 0, second: 0, of: flooring) else {
+            return nil
+        }
+        self.date = date
+    }
+
     public static var clickhouseDefault: ClickHouseDate32 {
         return .init(date: .init(timeIntervalSince1970: 0))
     }
 
-    public static func writeTo(buffer: inout ByteBuffer, array: [ClickHouseDate32], fixedLength: ClickHouseColumnMetadata?) {
-        let a = array.map {
+    public static func writeTo(buffer: inout ByteBuffer, array: [ClickHouseDate32], columnMetadata: ClickHouseColumnMetadata?) {
+        let intergerArray = array.map {
             Int32($0.date.timeIntervalSince1970 / (24 * 3600))
         }
-        buffer.writeIntegerArray(a)
+        buffer.writeIntegerArray(intergerArray)
     }
 
-    public static func getClickHouseTypeName(fixedLength: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
+    public static func getClickHouseTypeName(columnMetadata: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
         return .date32
     }
 
@@ -481,27 +495,37 @@ public struct ClickHouseDate32: ClickHouseDataType, CustomStringConvertible {
     }
 }
 
+/// Struct for the Date-ClickHouse-Type, has a date-field which is a swift-date
 public struct ClickHouseDate: ClickHouseDataType, CustomStringConvertible {
-    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, fixedLength: ClickHouseColumnMetadata?) -> [ClickHouseDate]? {
-        guard let a: [UInt16] = buffer.readIntegerArray(numRows: numRows) else {
+    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, columnMetadata: ClickHouseColumnMetadata?) -> [ClickHouseDate]? {
+        guard let intergerArray: [UInt16] = buffer.readIntegerArray(numRows: numRows) else {
             return nil
         }
-        return a.map {
-            .init(.init(timeIntervalSince1970: Double(24 * 3600 * Int($0))))
-        }
+        return intergerArray.map { .init(.init(timeIntervalSince1970: Double(24 * 3600 * Int($0)))) }
     }
 
     public static var clickhouseDefault: ClickHouseDate {
         return .init(.init(timeIntervalSince1970: 0))
     }
 
-    public static func writeTo(buffer: inout ByteBuffer, array: [ClickHouseDate], fixedLength: ClickHouseColumnMetadata?) {
-        let a: [UInt16] = array.map {
+    public static func writeTo(buffer: inout ByteBuffer, array: [ClickHouseDate], columnMetadata: ClickHouseColumnMetadata?) {
+        let intergerArray: [UInt16] = array.map {
             UInt16($0.date.timeIntervalSince1970 / (24 * 3600))
         }
-        buffer.writeIntegerArray(a)
+        buffer.writeIntegerArray(intergerArray)
     }
 
+    /// constructs a ClickHouseDate with the given Date without changing anything
+    public init(_ exact: Date) {
+        self.date = exact
+    }
+
+    init(date: Date) {
+        self.date = date
+    }
+
+    /// constructs a ClickHouseDate for the given Date while setting the hour, minute and second to 0
+    /// if the setting fails, returns nil
     public init?(flooring: Date) {
         guard let date = Calendar.current.date(bySettingHour: 0, minute: 0, second: 0, of: flooring) else {
             return nil
@@ -509,11 +533,7 @@ public struct ClickHouseDate: ClickHouseDataType, CustomStringConvertible {
         self.date = date
     }
 
-    public init(_ exact: Date) {
-        self.date = exact
-    }
-
-    public static func getClickHouseTypeName(fixedLength: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
+    public static func getClickHouseTypeName(columnMetadata: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
         return .date
     }
 
@@ -523,19 +543,29 @@ public struct ClickHouseDate: ClickHouseDataType, CustomStringConvertible {
         "\(date)"
     }
 }
+
+/// Struct for the DateTime64-ClickHouse-Type, has a date-field which is a swift-date
+/// When reading, all dates get coerced into the date-range 1900-01-01 00:00:00 to 2299-12-31 23:59:59
+/// as ClickHouse does so too when outputting the DateTime64 in String-form
 public struct ClickHouseDateTime64: ClickHouseDataType, CustomStringConvertible {
-    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, fixedLength: ClickHouseColumnMetadata?) -> [ClickHouseDateTime64]? {
-        guard case let .dateTime64Precision(precision, _) = fixedLength! else {
-            fatalError("dateTime64 should have dateTime64precision-enum for column-metadate, not\(timezone)")
+    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, columnMetadata: ClickHouseColumnMetadata?) -> [ClickHouseDateTime64]? {
+        guard let columnMetadata = columnMetadata,
+        case let .dateTime64Precision(precision, _) = columnMetadata else {
+            fatalError("dateTime64 should have dateTime64precision-enum for column-metadate, not \(String(describing: columnMetadata))")
         }
-        let hm: [Int64]? = buffer.readUnsafeGenericArray(numRows: numRows)
-        return hm?.map {
-            .init(
-                date: .init(timeIntervalSince1970: Double($0) / pow(
-                        10.0, Double(precision)
-                    )
-                )
-            )
+        guard let intergerArray: [Int64] = buffer.readIntegerArray(numRows: numRows) else {
+            return nil
+        }
+        return intergerArray.map {
+            let precisionFactor = pow(10.0, -1.0 * Double(precision))
+            let secondsSince1970 = Double($0) * precisionFactor
+            guard secondsSince1970 >= -2_208_988_800.0 else {
+                return .init(date: .init(timeIntervalSince1970: -2_208_988_800.0 ))
+            }
+            guard secondsSince1970 < 10_413_792_000.0 else {
+                return .init(date: .init(timeIntervalSince1970: 10_413_791_999.9 ))
+            }
+            return .init(date: .init(timeIntervalSince1970: secondsSince1970 ))
         }
     }
 
@@ -543,20 +573,18 @@ public struct ClickHouseDateTime64: ClickHouseDataType, CustomStringConvertible 
         return .init(date: .init(timeIntervalSince1970: 0))
     }
 
-    public static func writeTo(buffer: inout ByteBuffer, array: [ClickHouseDateTime64], fixedLength: ClickHouseColumnMetadata?) {
-        guard case let .dateTime64Precision(precision, _) = fixedLength! else {
-            fatalError("dateTime64 should have dateTime64precision-enum for column-metadate, not\(timezone)")
+    public static func writeTo(buffer: inout ByteBuffer, array: [ClickHouseDateTime64], columnMetadata: ClickHouseColumnMetadata?) {
+        guard let columnMetadata = columnMetadata, case let .dateTime64Precision(precision, _) = columnMetadata else {
+            fatalError("dateTime64 should have dateTime64precision-enum for column-metadate, not\(String(describing: columnMetadata))")
         }
-        let hm = array.map({
+        let intergerArray = array.map({
             Int64($0.date.timeIntervalSince1970 * pow(10.0, Double(precision)))
         })
-        let _ = hm.withUnsafeBytes {
-            buffer.writeBytes($0)
-        }
+        buffer.writeIntegerArray(intergerArray)
     }
 
-    public static func getClickHouseTypeName(fixedLength: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
-        return .dateTime64(fixedLength!)
+    public static func getClickHouseTypeName(columnMetadata: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
+        return .dateTime64(columnMetadata!)
     }
 
     public var date: Date
@@ -574,30 +602,29 @@ public struct ClickHouseDateTime64: ClickHouseDataType, CustomStringConvertible 
     }
 }
 
+/// Struct for the DateTime-ClickHouse-Type, has a date-field which is a swift-date
 public struct ClickHouseDateTime: ClickHouseDataType, CustomStringConvertible {
-    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, fixedLength: ClickHouseColumnMetadata?) -> [ClickHouseDateTime]? {
-        guard let a: [UInt32] = buffer.readIntegerArray(numRows: numRows) else {
+    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, columnMetadata: ClickHouseColumnMetadata?) -> [ClickHouseDateTime]? {
+        guard let intergerArray: [UInt32] = buffer.readIntegerArray(numRows: numRows) else {
             return nil
         }
-        return a.map {
-            .init(date: .init(timeIntervalSince1970: Double($0)))
-        }
+        return intergerArray.map { .init(date: .init(timeIntervalSince1970: Double($0))) }
     }
 
     public static var clickhouseDefault: ClickHouseDateTime {
         return .init(date: .init(timeIntervalSince1970: 0))
     }
 
-    public static func writeTo(buffer: inout ByteBuffer, array: [ClickHouseDateTime], fixedLength: ClickHouseColumnMetadata?) {
-        let a = array.map {
+    public static func writeTo(buffer: inout ByteBuffer, array: [ClickHouseDateTime], columnMetadata: ClickHouseColumnMetadata?) {
+        let intergerArray = array.map {
             UInt32($0.date.timeIntervalSince1970)
         }
-        buffer.writeIntegerArray(a)
+        buffer.writeIntegerArray(intergerArray)
     }
 
-    public static func getClickHouseTypeName(fixedLength: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
-        if let fixedLength = fixedLength,
-            case let .dateTimeTimeZone(timeZone) = fixedLength {
+    public static func getClickHouseTypeName(columnMetadata: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
+        if let columnMetadata = columnMetadata,
+            case let .dateTimeTimeZone(timeZone) = columnMetadata {
             return .dateTime(.dateTimeTimeZone(timeZone))
         }
         return .dateTime(.dateTimeTimeZone(nil))
@@ -618,17 +645,19 @@ public struct ClickHouseDateTime: ClickHouseDataType, CustomStringConvertible {
     }
 }
 
+/// Struct for an Enum based on an Int8, only has the word-field which is a String
+/// and the string representation of the enum, it doesn't know the corresponding Int8
 public struct ClickHouseEnum8: ClickHouseDataType, CustomStringConvertible {
     public var word: String
-    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, fixedLength: ClickHouseColumnMetadata?) -> [ClickHouseEnum8]? {
-        guard case let .enum8Map(mapping) = fixedLength! else {
+    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, columnMetadata: ClickHouseColumnMetadata?) -> [ClickHouseEnum8]? {
+        guard case let .enum8Map(mapping) = columnMetadata! else {
             fatalError("enum8 should have enum8Map-enum for column-metadate, not\(timezone)")
         }
-        let ma2 = [Int8: String](uniqueKeysWithValues: zip(mapping.values, mapping.keys))
-        let hm: [Int8]? = buffer.readIntegerArray(numRows: numRows)
-        return hm?.map({
-            return ClickHouseEnum8(word: ma2[$0]!)
-        })
+        let reversedEnumMapping = [Int8: String](uniqueKeysWithValues: zip(mapping.values, mapping.keys))
+        guard let intergerArray: [Int8] = buffer.readIntegerArray(numRows: numRows) else {
+            return nil
+        }
+        return intergerArray.map { return ClickHouseEnum8(word: reversedEnumMapping[$0]!) }
     }
 
     public static var clickhouseDefault: ClickHouseEnum8 {
@@ -639,33 +668,34 @@ public struct ClickHouseEnum8: ClickHouseDataType, CustomStringConvertible {
         self.word = word
     }
 
-    public static func writeTo(buffer: inout ByteBuffer, array: [ClickHouseEnum8], fixedLength: ClickHouseColumnMetadata?) {
-        guard case let .enum8Map(mapping) = fixedLength! else {
+    public static func writeTo(buffer: inout ByteBuffer, array: [ClickHouseEnum8], columnMetadata: ClickHouseColumnMetadata?) {
+        guard case let .enum8Map(mapping) = columnMetadata! else {
             fatalError("enum8 should have enum8Map-enum for column-metadate, not\(timezone)")
         }
-        let hm = array.map { mapping[$0.word]! }
-        buffer.writeIntegerArray(hm)
+        let intergerArray = array.map { mapping[$0.word]! }
+        buffer.writeIntegerArray(intergerArray)
     }
 
-    public static func getClickHouseTypeName(fixedLength: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
-        return .enum8(fixedLength!)
+    public static func getClickHouseTypeName(columnMetadata: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
+        return .enum8(columnMetadata!)
     }
 
     public var description: String {
         "\(word)"
     }
 }
-
+/// Struct for an Enum based on an Int16, only has the word-field which is a String
+/// and the string representation of the enum, it doesn't know the corresponding Int16
 public struct ClickHouseEnum16: ClickHouseDataType, CustomStringConvertible {
     public var word: String
-    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, fixedLength: ClickHouseColumnMetadata?) -> [ClickHouseEnum16]? {
-        guard case let .enum16Map(mapping) = fixedLength! else {
+    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, columnMetadata: ClickHouseColumnMetadata?) -> [ClickHouseEnum16]? {
+        guard case let .enum16Map(mapping) = columnMetadata! else {
             fatalError("enum16 should have enum16Map-enum for column-metadate, not\(timezone)")
         }
-        let ma2 = [Int16: String](uniqueKeysWithValues: zip(mapping.values, mapping.keys))
-        let hm: [Int16]? = buffer.readIntegerArray(numRows: numRows)
-        return hm?.map({
-            return ClickHouseEnum16(word: ma2[$0]!)
+        let reversedEnumMapping = [Int16: String](uniqueKeysWithValues: zip(mapping.values, mapping.keys))
+        let intergerArray: [Int16]? = buffer.readIntegerArray(numRows: numRows)
+        return intergerArray?.map({
+            return ClickHouseEnum16(word: reversedEnumMapping[$0]!)
         })
     }
 
@@ -677,16 +707,16 @@ public struct ClickHouseEnum16: ClickHouseDataType, CustomStringConvertible {
         return .init(word: "")
     }
 
-    public static func writeTo(buffer: inout ByteBuffer, array: [ClickHouseEnum16], fixedLength: ClickHouseColumnMetadata?) {
-        guard case let .enum16Map(mapping) = fixedLength! else {
+    public static func writeTo(buffer: inout ByteBuffer, array: [ClickHouseEnum16], columnMetadata: ClickHouseColumnMetadata?) {
+        guard case let .enum16Map(mapping) = columnMetadata! else {
             fatalError("enum16 should have enum16Map-enum for column-metadate, not\(timezone)")
         }
-        let hm = array.map { mapping[$0.word]! }
-        buffer.writeIntegerArray(hm)
+        let intergerArray = array.map { mapping[$0.word]! }
+        buffer.writeIntegerArray(intergerArray)
     }
 
-    public static func getClickHouseTypeName(fixedLength: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
-        return .enum16(fixedLength!)
+    public static func getClickHouseTypeName(columnMetadata: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
+        return .enum16(columnMetadata!)
     }
 
     public var description: String {
@@ -695,11 +725,11 @@ public struct ClickHouseEnum16: ClickHouseDataType, CustomStringConvertible {
 }
 
 extension String: ClickHouseDataType {
-    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, fixedLength: ClickHouseColumnMetadata?) -> [String]? {
+    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, columnMetadata: ClickHouseColumnMetadata?) -> [String]? {
 
-        if let fixedLength = fixedLength {
-            guard case let .fixedStringLength(fixedLength) = fixedLength else {
-                fatalError("fixed-length strings should have fixedStringLength-enum for column-metadata, not \(fixedLength)")
+        if let columnMetadata = columnMetadata {
+            guard case let .fixedStringLength(fixedLength) = columnMetadata else {
+                fatalError("fixed-length strings should have fixedStringLength-enum for column-metadata, not \(columnMetadata)")
             }
             var strings = [String]()
             strings.reserveCapacity(numRows)
@@ -720,7 +750,7 @@ extension String: ClickHouseDataType {
         return buffer.readClickHouseStrings(numRows: numRows)
     }
 
-    public func clickhouseReadValue(buffer: inout ByteBuffer, fixedLength: ClickHouseColumnMetadata?) -> String? {
+    public func clickhouseReadValue(buffer: inout ByteBuffer, columnMetadata: ClickHouseColumnMetadata?) -> String? {
         return buffer.readClickHouseString()
     }
 
@@ -728,10 +758,10 @@ extension String: ClickHouseDataType {
         return ""
     }
 
-    public static func writeTo(buffer: inout ByteBuffer, array: [String], fixedLength: ClickHouseColumnMetadata?) {
-        if let length = fixedLength {
-            guard case let .fixedStringLength(length) = length else {
-                fatalError("fixed-length strings should have fixedStringLength-enum for column-metadata, not \(length)")
+    public static func writeTo(buffer: inout ByteBuffer, array: [String], columnMetadata: ClickHouseColumnMetadata?) {
+        if let columnMetadata = columnMetadata {
+            guard case let .fixedStringLength(length) = columnMetadata else {
+                fatalError("strings should have fixedStringLength-enum for fixed length strings or nothing for column-metadata, not \(columnMetadata)")
             }
             buffer.writeClickHouseFixedStrings(array, length: length)
         } else {
@@ -739,8 +769,8 @@ extension String: ClickHouseDataType {
         }
     }
 
-    public static func getClickHouseTypeName(fixedLength: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
-        if let len = fixedLength {
+    public static func getClickHouseTypeName(columnMetadata: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
+        if let len = columnMetadata {
             return .fixedString(len)
         }
         return .string
@@ -748,7 +778,7 @@ extension String: ClickHouseDataType {
 }
 
 extension Int8: ClickHouseDataType {
-    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, fixedLength: ClickHouseColumnMetadata?) -> [Int8]? {
+    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, columnMetadata: ClickHouseColumnMetadata?) -> [Int8]? {
         return buffer.readIntegerArray(numRows: numRows)
     }
 
@@ -756,17 +786,17 @@ extension Int8: ClickHouseDataType {
         return 0
     }
 
-    public static func writeTo(buffer: inout ByteBuffer, array: [Int8], fixedLength: ClickHouseColumnMetadata?) {
+    public static func writeTo(buffer: inout ByteBuffer, array: [Int8], columnMetadata: ClickHouseColumnMetadata?) {
         buffer.writeIntegerArray(array)
     }
 
-    public static func getClickHouseTypeName(fixedLength: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
+    public static func getClickHouseTypeName(columnMetadata: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
         return .int8
     }
 }
 
 extension Bool: ClickHouseDataType {
-    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, fixedLength: ClickHouseColumnMetadata?) -> [Bool]? {
+    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, columnMetadata: ClickHouseColumnMetadata?) -> [Bool]? {
         return buffer.readUnsafeGenericArray(numRows: numRows)
     }
 
@@ -774,19 +804,19 @@ extension Bool: ClickHouseDataType {
         return false
     }
 
-    public static func writeTo(buffer: inout ByteBuffer, array: [Bool], fixedLength: ClickHouseColumnMetadata?) {
+    public static func writeTo(buffer: inout ByteBuffer, array: [Bool], columnMetadata: ClickHouseColumnMetadata?) {
         let _ = array.withUnsafeBytes {
             buffer.writeBytes($0)
         }
     }
 
-    public static func getClickHouseTypeName(fixedLength: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
+    public static func getClickHouseTypeName(columnMetadata: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
         return .boolean
     }
 }
 
 extension Int16: ClickHouseDataType {
-    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, fixedLength: ClickHouseColumnMetadata?) -> [Int16]? {
+    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, columnMetadata: ClickHouseColumnMetadata?) -> [Int16]? {
         return buffer.readIntegerArray(numRows: numRows)
     }
 
@@ -794,17 +824,17 @@ extension Int16: ClickHouseDataType {
         return 0
     }
 
-    public static func writeTo(buffer: inout ByteBuffer, array: [Int16], fixedLength: ClickHouseColumnMetadata?) {
+    public static func writeTo(buffer: inout ByteBuffer, array: [Int16], columnMetadata: ClickHouseColumnMetadata?) {
         buffer.writeIntegerArray(array)
     }
 
-    public static func getClickHouseTypeName(fixedLength: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
+    public static func getClickHouseTypeName(columnMetadata: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
         return .int16
     }
 }
 
 extension Int32: ClickHouseDataType {
-    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, fixedLength: ClickHouseColumnMetadata?) -> [Int32]? {
+    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, columnMetadata: ClickHouseColumnMetadata?) -> [Int32]? {
         return buffer.readIntegerArray(numRows: numRows)
     }
 
@@ -812,17 +842,17 @@ extension Int32: ClickHouseDataType {
         return 0
     }
 
-    public static func writeTo(buffer: inout ByteBuffer, array: [Int32], fixedLength: ClickHouseColumnMetadata?) {
+    public static func writeTo(buffer: inout ByteBuffer, array: [Int32], columnMetadata: ClickHouseColumnMetadata?) {
         buffer.writeIntegerArray(array)
     }
 
-    public static func getClickHouseTypeName(fixedLength: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
+    public static func getClickHouseTypeName(columnMetadata: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
         return .int32
     }
 }
 
 extension Int64: ClickHouseDataType {
-    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, fixedLength: ClickHouseColumnMetadata?) -> [Int64]? {
+    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, columnMetadata: ClickHouseColumnMetadata?) -> [Int64]? {
         return buffer.readIntegerArray(numRows: numRows)
     }
 
@@ -830,17 +860,17 @@ extension Int64: ClickHouseDataType {
         return 0
     }
 
-    public static func writeTo(buffer: inout ByteBuffer, array: [Int64], fixedLength: ClickHouseColumnMetadata?) {
+    public static func writeTo(buffer: inout ByteBuffer, array: [Int64], columnMetadata: ClickHouseColumnMetadata?) {
         buffer.writeIntegerArray(array)
     }
 
-    public static func getClickHouseTypeName(fixedLength: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
+    public static func getClickHouseTypeName(columnMetadata: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
         return .int64
     }
 }
 
 extension UInt8: ClickHouseDataType {
-    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, fixedLength: ClickHouseColumnMetadata?) -> [UInt8]? {
+    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, columnMetadata: ClickHouseColumnMetadata?) -> [UInt8]? {
         return buffer.readIntegerArray(numRows: numRows)
     }
 
@@ -848,17 +878,17 @@ extension UInt8: ClickHouseDataType {
         return 0
     }
 
-    public static func writeTo(buffer: inout ByteBuffer, array: [UInt8], fixedLength: ClickHouseColumnMetadata?) {
+    public static func writeTo(buffer: inout ByteBuffer, array: [UInt8], columnMetadata: ClickHouseColumnMetadata?) {
         buffer.writeIntegerArray(array)
     }
 
-    public static func getClickHouseTypeName(fixedLength: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
+    public static func getClickHouseTypeName(columnMetadata: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
         return .uint8
     }
 }
 
 extension UInt16: ClickHouseDataType {
-    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, fixedLength: ClickHouseColumnMetadata?) -> [UInt16]? {
+    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, columnMetadata: ClickHouseColumnMetadata?) -> [UInt16]? {
         return buffer.readIntegerArray(numRows: numRows)
     }
 
@@ -866,17 +896,17 @@ extension UInt16: ClickHouseDataType {
         return 0
     }
 
-    public static func writeTo(buffer: inout ByteBuffer, array: [UInt16], fixedLength: ClickHouseColumnMetadata?) {
+    public static func writeTo(buffer: inout ByteBuffer, array: [UInt16], columnMetadata: ClickHouseColumnMetadata?) {
         buffer.writeIntegerArray(array)
     }
 
-    public static func getClickHouseTypeName(fixedLength: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
+    public static func getClickHouseTypeName(columnMetadata: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
         return .uint16
     }
 }
 
 extension UInt32: ClickHouseDataType {
-    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, fixedLength: ClickHouseColumnMetadata?) -> [UInt32]? {
+    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, columnMetadata: ClickHouseColumnMetadata?) -> [UInt32]? {
         return buffer.readIntegerArray(numRows: numRows)
     }
 
@@ -884,17 +914,17 @@ extension UInt32: ClickHouseDataType {
         return 0
     }
 
-    public static func writeTo(buffer: inout ByteBuffer, array: [UInt32], fixedLength: ClickHouseColumnMetadata?) {
+    public static func writeTo(buffer: inout ByteBuffer, array: [UInt32], columnMetadata: ClickHouseColumnMetadata?) {
         buffer.writeIntegerArray(array)
     }
 
-    public static func getClickHouseTypeName(fixedLength: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
+    public static func getClickHouseTypeName(columnMetadata: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
         return .uint32
     }
 }
 
 extension UInt64: ClickHouseDataType {
-    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, fixedLength: ClickHouseColumnMetadata?) -> [UInt64]? {
+    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, columnMetadata: ClickHouseColumnMetadata?) -> [UInt64]? {
         return buffer.readIntegerArray(numRows: numRows)
     }
 
@@ -902,17 +932,17 @@ extension UInt64: ClickHouseDataType {
         return 0
     }
 
-    public static func writeTo(buffer: inout ByteBuffer, array: [UInt64], fixedLength: ClickHouseColumnMetadata?) {
+    public static func writeTo(buffer: inout ByteBuffer, array: [UInt64], columnMetadata: ClickHouseColumnMetadata?) {
         buffer.writeIntegerArray(array)
     }
 
-    public static func getClickHouseTypeName(fixedLength: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
+    public static func getClickHouseTypeName(columnMetadata: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
         return .uint64
     }
 }
 
 extension Float: ClickHouseDataType {
-    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, fixedLength: ClickHouseColumnMetadata?) -> [Float]? {
+    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, columnMetadata: ClickHouseColumnMetadata?) -> [Float]? {
         return buffer.readUnsafeGenericArray(numRows: numRows)
     }
 
@@ -920,19 +950,19 @@ extension Float: ClickHouseDataType {
         return 0
     }
 
-    public static func writeTo(buffer: inout ByteBuffer, array: [Float], fixedLength: ClickHouseColumnMetadata?) {
+    public static func writeTo(buffer: inout ByteBuffer, array: [Float], columnMetadata: ClickHouseColumnMetadata?) {
         let _ = array.withUnsafeBytes {
             buffer.writeBytes($0)
         }
     }
 
-    public static func getClickHouseTypeName(fixedLength: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
+    public static func getClickHouseTypeName(columnMetadata: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
         return .float
     }
 }
 
 extension Double: ClickHouseDataType {
-    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, fixedLength: ClickHouseColumnMetadata?) -> [Double]? {
+    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, columnMetadata: ClickHouseColumnMetadata?) -> [Double]? {
         return buffer.readUnsafeGenericArray(numRows: numRows)
     }
 
@@ -940,19 +970,19 @@ extension Double: ClickHouseDataType {
         return 0
     }
 
-    public static func writeTo(buffer: inout ByteBuffer, array: [Double], fixedLength: ClickHouseColumnMetadata?) {
+    public static func writeTo(buffer: inout ByteBuffer, array: [Double], columnMetadata: ClickHouseColumnMetadata?) {
         let _ = array.withUnsafeBytes {
             buffer.writeBytes($0)
         }
     }
 
-    public static func getClickHouseTypeName(fixedLength: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
+    public static func getClickHouseTypeName(columnMetadata: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
         return .float64
     }
 }
 
 extension UUID: ClickHouseDataType {
-    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, fixedLength: ClickHouseColumnMetadata?) -> [UUID]? {
+    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, columnMetadata: ClickHouseColumnMetadata?) -> [UUID]? {
         return buffer.readUuidArray(numRows: numRows, endianness: .little)
     }
 
@@ -960,17 +990,17 @@ extension UUID: ClickHouseDataType {
         return UUID(uuidString: "00000000-0000-0000-0000-000000000000")!
     }
 
-    public static func writeTo(buffer: inout ByteBuffer, array: [UUID], fixedLength: ClickHouseColumnMetadata?) {
+    public static func writeTo(buffer: inout ByteBuffer, array: [UUID], columnMetadata: ClickHouseColumnMetadata?) {
         buffer.writeUuidArray(array, endianness: .little)
     }
 
-    public static func getClickHouseTypeName(fixedLength: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
+    public static func getClickHouseTypeName(columnMetadata: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
         return .uuid
     }
 }
 
 extension Optional: ClickHouseDataType where Wrapped: ClickHouseDataType {
-    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, fixedLength: ClickHouseColumnMetadata?) -> [Optional<Wrapped>]? {
+    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, columnMetadata: ClickHouseColumnMetadata?) -> [Optional<Wrapped>]? {
         var bufferCopy = buffer
 
         guard bufferCopy.readableBytes >= (1) * numRows else {
@@ -985,7 +1015,7 @@ extension Optional: ClickHouseDataType where Wrapped: ClickHouseDataType {
             isnull.append(set == 1)
         }
 
-        guard let data = Wrapped.readFrom(buffer: &bufferCopy, numRows: numRows, fixedLength: fixedLength) else {
+        guard let data = Wrapped.readFrom(buffer: &bufferCopy, numRows: numRows, columnMetadata: columnMetadata) else {
             return nil
         }
         let mapped = data.enumerated().map({
@@ -999,7 +1029,7 @@ extension Optional: ClickHouseDataType where Wrapped: ClickHouseDataType {
         return nil
     }
 
-    public static func writeTo(buffer: inout ByteBuffer, array: [Optional<Wrapped>], fixedLength: ClickHouseColumnMetadata?) {
+    public static func writeTo(buffer: inout ByteBuffer, array: [Optional<Wrapped>], columnMetadata: ClickHouseColumnMetadata?) {
         buffer.reserveCapacity(array.count * (1) + buffer.writableBytes)
         // Frist write one array with 0/1 for nullable, then data
         for element in array {
@@ -1015,33 +1045,18 @@ extension Optional: ClickHouseDataType where Wrapped: ClickHouseDataType {
             }
             return value
         }
-        Wrapped.writeTo(buffer: &buffer, array: mapped, fixedLength: fixedLength)
+        Wrapped.writeTo(buffer: &buffer, array: mapped, columnMetadata: columnMetadata)
     }
 
-    public static func getClickHouseTypeName(fixedLength: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
-        return .nullable(Wrapped.getClickHouseTypeName(fixedLength: fixedLength))
+    public static func getClickHouseTypeName(columnMetadata: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
+        return .nullable(Wrapped.getClickHouseTypeName(columnMetadata: columnMetadata))
     }
 }
 
 extension Array: ClickHouseDataType where Element: ClickHouseDataType {
-    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, fixedLength: ClickHouseColumnMetadata?) -> [[Element]]? {
-        guard numRows > 0 else {
-            return  []
-        }
-
-        guard buffer.readableBytes >= (1) * numRows else {
+    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, columnMetadata: ClickHouseColumnMetadata?) -> [[Element]]? {
+        guard let offsets: [UInt64] = buffer.readIntegerArray(numRows: numRows) else {
             return nil
-        }
-
-        var offsets = [UInt64]()
-        offsets.reserveCapacity(numRows)
-
-        for _ in 0..<(numRows) {
-            guard let set: UInt64 = buffer.readInteger(endianness: .little) else {
-                return nil // need more data
-            }
-
-            offsets.append(set)
         }
 
         var array: [[Element]] = []
@@ -1049,11 +1064,11 @@ extension Array: ClickHouseDataType where Element: ClickHouseDataType {
         var last = 0
 
         for i1 in offsets {
-            guard let ele = Element.readFrom(buffer: &buffer, numRows: Int(i1) - last, fixedLength: fixedLength) else {
+            guard let elements = Element.readFrom(buffer: &buffer, numRows: Int(i1) - last, columnMetadata: columnMetadata) else {
                 return nil // need more data
             }
 
-            array.append(ele)
+            array.append(elements)
             last = Int(i1)
         }
 
@@ -1064,22 +1079,14 @@ extension Array: ClickHouseDataType where Element: ClickHouseDataType {
         return []
     }
 
-    public static func writeTo(buffer: inout ByteBuffer, array: [[Element]], fixedLength: ClickHouseColumnMetadata?) {
-       var offsets: [UInt64] = []
-        offsets.reserveCapacity(array.count)
-
-        for a in array {
-            offsets.append((offsets.last ?? 0) + UInt64(a.count))
-        }
-
-        buffer.writeIntegerArray(offsets)
-
+    public static func writeTo(buffer: inout ByteBuffer, array: [[Element]], columnMetadata: ClickHouseColumnMetadata?) {
+        buffer.writeIntegerArray(array.map { UInt64($0.count) } )
         array.forEach {
-            Element.writeTo(buffer: &buffer, array: $0, fixedLength: fixedLength)
+            Element.writeTo(buffer: &buffer, array: $0, columnMetadata: columnMetadata)
         }
     }
 
-    public static func getClickHouseTypeName(fixedLength: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
-        return .array(Element.getClickHouseTypeName(fixedLength: fixedLength))
+    public static func getClickHouseTypeName(columnMetadata: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
+        return .array(Element.getClickHouseTypeName(columnMetadata: columnMetadata))
     }
 }

--- a/Sources/ClickHouseNIO/ClickHouseArray.swift
+++ b/Sources/ClickHouseNIO/ClickHouseArray.swift
@@ -225,9 +225,9 @@ public indirect enum ClickHouseTypeName {
             return "Int64"
         case .uint64:
             return "UInt64"
-        case .fixedString(let len):
-            guard case let .fixedStringLength(len) = len else {
-                fatalError("fixed-length strings should have fixedStringLength-enum for column-metadata, not \(len)")
+        case .fixedString(let lenOuter):
+            guard case let .fixedStringLength(len) = lenOuter else {
+                fatalError("fixed-length strings should have fixedStringLength-enum for column-metadata, not \(lenOuter)")
             }
             return "FixedString(\(len))"
         case .string:

--- a/Sources/ClickHouseNIO/ClickHouseArray.swift
+++ b/Sources/ClickHouseNIO/ClickHouseArray.swift
@@ -445,27 +445,27 @@ public struct ClickHouseDate32: ClickHouseDataType, CustomStringConvertible {
             return nil
         }
         return a.map {
-            .init(_date:
+            .init(date:
                 Date(timeIntervalSince1970: Double(24 * 3600 * Int($0)))
             )
         }
     }
 
     public init(_ exact: Date) {
-        self._date = exact
+        self.date = exact
     }
 
-    init(_date: Date) {
-        self._date = _date
+    init(date: Date) {
+        self.date = date
     }
 
     public static var clickhouseDefault: ClickHouseDate32 {
-        return .init(_date: .init(timeIntervalSince1970: 0))
+        return .init(date: .init(timeIntervalSince1970: 0))
     }
 
     public static func writeTo(buffer: inout ByteBuffer, array: [ClickHouseDate32], fixedLength: ClickHouseColumnMetadata?) {
         let a = array.map {
-            Int32($0._date.timeIntervalSince1970 / (24 * 3600))
+            Int32($0.date.timeIntervalSince1970 / (24 * 3600))
         }
         buffer.writeIntegerArray(a)
     }
@@ -474,10 +474,10 @@ public struct ClickHouseDate32: ClickHouseDataType, CustomStringConvertible {
         return .date32
     }
 
-    public var _date: Date
+    public var date: Date
 
     public var description: String {
-        "\(_date)"
+        "\(date)"
     }
 }
 
@@ -497,30 +497,30 @@ public struct ClickHouseDate: ClickHouseDataType, CustomStringConvertible {
 
     public static func writeTo(buffer: inout ByteBuffer, array: [ClickHouseDate], fixedLength: ClickHouseColumnMetadata?) {
         let a: [UInt16] = array.map {
-            UInt16($0._date.timeIntervalSince1970 / (24 * 3600))
+            UInt16($0.date.timeIntervalSince1970 / (24 * 3600))
         }
         buffer.writeIntegerArray(a)
     }
 
     public init?(flooring: Date) {
-        guard let _date = Calendar.current.date(bySettingHour: 0, minute: 0, second: 0, of: flooring) else {
+        guard let date = Calendar.current.date(bySettingHour: 0, minute: 0, second: 0, of: flooring) else {
             return nil
         }
-        self._date = _date
+        self.date = date
     }
 
     public init(_ exact: Date) {
-        self._date = exact
+        self.date = exact
     }
 
     public static func getClickHouseTypeName(fixedLength: ClickHouseColumnMetadata?) -> ClickHouseTypeName {
         return .date
     }
 
-    public var _date: Date
+    public var date: Date
 
     public var description: String {
-        "\(_date)"
+        "\(date)"
     }
 }
 public struct ClickHouseDateTime64: ClickHouseDataType, CustomStringConvertible {
@@ -531,7 +531,7 @@ public struct ClickHouseDateTime64: ClickHouseDataType, CustomStringConvertible 
         let hm: [Int64]? = buffer.readUnsafeGenericArray(numRows: numRows)
         return hm?.map {
             .init(
-                _date: .init(timeIntervalSince1970: Double($0) / pow(
+                date: .init(timeIntervalSince1970: Double($0) / pow(
                         10.0, Double(precision)
                     )
                 )
@@ -540,7 +540,7 @@ public struct ClickHouseDateTime64: ClickHouseDataType, CustomStringConvertible 
     }
 
     public static var clickhouseDefault: ClickHouseDateTime64 {
-        return .init(_date: .init(timeIntervalSince1970: 0))
+        return .init(date: .init(timeIntervalSince1970: 0))
     }
 
     public static func writeTo(buffer: inout ByteBuffer, array: [ClickHouseDateTime64], fixedLength: ClickHouseColumnMetadata?) {
@@ -548,7 +548,7 @@ public struct ClickHouseDateTime64: ClickHouseDataType, CustomStringConvertible 
             fatalError("dateTime64 should have dateTime64precision-enum for column-metadate, not\(timezone)")
         }
         let hm = array.map({
-            Int64($0._date.timeIntervalSince1970 * pow(10.0, Double(precision)))
+            Int64($0.date.timeIntervalSince1970 * pow(10.0, Double(precision)))
         })
         let _ = hm.withUnsafeBytes {
             buffer.writeBytes($0)
@@ -559,18 +559,18 @@ public struct ClickHouseDateTime64: ClickHouseDataType, CustomStringConvertible 
         return .dateTime64(fixedLength!)
     }
 
-    public var _date: Date
+    public var date: Date
 
     public init(_ exact: Date) {
-        self._date = exact
+        self.date = exact
     }
 
-    init(_date: Date) {
-        self._date = _date
+    init(date: Date) {
+        self.date = date
     }
 
     public var description: String {
-        "\(_date)"
+        "\(date)"
     }
 }
 
@@ -580,17 +580,17 @@ public struct ClickHouseDateTime: ClickHouseDataType, CustomStringConvertible {
             return nil
         }
         return a.map {
-            .init(_date: .init(timeIntervalSince1970: Double($0)))
+            .init(date: .init(timeIntervalSince1970: Double($0)))
         }
     }
 
     public static var clickhouseDefault: ClickHouseDateTime {
-        return .init(_date: .init(timeIntervalSince1970: 0))
+        return .init(date: .init(timeIntervalSince1970: 0))
     }
 
     public static func writeTo(buffer: inout ByteBuffer, array: [ClickHouseDateTime], fixedLength: ClickHouseColumnMetadata?) {
         let a = array.map {
-            UInt32($0._date.timeIntervalSince1970)
+            UInt32($0.date.timeIntervalSince1970)
         }
         buffer.writeIntegerArray(a)
     }
@@ -603,23 +603,23 @@ public struct ClickHouseDateTime: ClickHouseDataType, CustomStringConvertible {
         return .dateTime(.dateTimeTimeZone(nil))
     }
 
-    public var _date: Date
+    public var date: Date
 
     public init(_ exact: Date) {
-        self._date = exact
+        self.date = exact
     }
 
-    init(_date: Date) {
-        self._date = _date
+    init(date: Date) {
+        self.date = date
     }
 
     public var description: String {
-        "\(_date)"
+        "\(date)"
     }
 }
 
 public struct ClickHouseEnum8: ClickHouseDataType, CustomStringConvertible {
-    public var __str: String
+    public var word: String
     public static func readFrom(buffer: inout ByteBuffer, numRows: Int, fixedLength: ClickHouseColumnMetadata?) -> [ClickHouseEnum8]? {
         guard case let .enum8Map(mapping) = fixedLength! else {
             fatalError("enum8 should have enum8Map-enum for column-metadate, not\(timezone)")
@@ -627,23 +627,23 @@ public struct ClickHouseEnum8: ClickHouseDataType, CustomStringConvertible {
         let ma2 = [Int8: String](uniqueKeysWithValues: zip(mapping.values, mapping.keys))
         let hm: [Int8]? = buffer.readIntegerArray(numRows: numRows)
         return hm?.map({
-            return ClickHouseEnum8(__str: ma2[$0]!)
+            return ClickHouseEnum8(word: ma2[$0]!)
         })
     }
 
     public static var clickhouseDefault: ClickHouseEnum8 {
-        return .init(__str: "")
+        return .init(word: "")
     }
 
-    public init(__str: String) {
-        self.__str = __str
+    public init(word: String) {
+        self.word = word
     }
 
     public static func writeTo(buffer: inout ByteBuffer, array: [ClickHouseEnum8], fixedLength: ClickHouseColumnMetadata?) {
         guard case let .enum8Map(mapping) = fixedLength! else {
             fatalError("enum8 should have enum8Map-enum for column-metadate, not\(timezone)")
         }
-        let hm = array.map { mapping[$0.__str]! }
+        let hm = array.map { mapping[$0.word]! }
         buffer.writeIntegerArray(hm)
     }
 
@@ -652,12 +652,12 @@ public struct ClickHouseEnum8: ClickHouseDataType, CustomStringConvertible {
     }
 
     public var description: String {
-        "\(__str)"
+        "\(word)"
     }
 }
 
 public struct ClickHouseEnum16: ClickHouseDataType, CustomStringConvertible {
-    public var __str: String
+    public var word: String
     public static func readFrom(buffer: inout ByteBuffer, numRows: Int, fixedLength: ClickHouseColumnMetadata?) -> [ClickHouseEnum16]? {
         guard case let .enum16Map(mapping) = fixedLength! else {
             fatalError("enum16 should have enum16Map-enum for column-metadate, not\(timezone)")
@@ -665,23 +665,23 @@ public struct ClickHouseEnum16: ClickHouseDataType, CustomStringConvertible {
         let ma2 = [Int16: String](uniqueKeysWithValues: zip(mapping.values, mapping.keys))
         let hm: [Int16]? = buffer.readIntegerArray(numRows: numRows)
         return hm?.map({
-            return ClickHouseEnum16(__str: ma2[$0]!)
+            return ClickHouseEnum16(word: ma2[$0]!)
         })
     }
 
-    public init(__str: String) {
-        self.__str = __str
+    public init(word: String) {
+        self.word = word
     }
 
     public static var clickhouseDefault: ClickHouseEnum16 {
-        return .init(__str: "")
+        return .init(word: "")
     }
 
     public static func writeTo(buffer: inout ByteBuffer, array: [ClickHouseEnum16], fixedLength: ClickHouseColumnMetadata?) {
         guard case let .enum16Map(mapping) = fixedLength! else {
             fatalError("enum16 should have enum16Map-enum for column-metadate, not\(timezone)")
         }
-        let hm = array.map { mapping[$0.__str]! }
+        let hm = array.map { mapping[$0.word]! }
         buffer.writeIntegerArray(hm)
     }
 
@@ -690,7 +690,7 @@ public struct ClickHouseEnum16: ClickHouseDataType, CustomStringConvertible {
     }
 
     public var description: String {
-        "\(__str)"
+        "\(word)"
     }
 }
 

--- a/Sources/ClickHouseNIO/ClickHouseArray.swift
+++ b/Sources/ClickHouseNIO/ClickHouseArray.swift
@@ -257,7 +257,7 @@ public indirect enum ClickHouseTypeName {
             return "Date32"
         case .dateTime(let timezoneDataOuter):
             guard case let .dateTimeTimeZone(timezoneData) = timezoneDataOuter else {
-                fatalError("dateTime should have dateTimeTimeZone-enum for column-metadata, not\(timezoneDataOuter)")
+                fatalError("dateTime should have dateTimeTimeZone-enum for column-metadata, not \(timezoneDataOuter)")
             }
             if let timezoneData = timezoneData {
                 return "DateTime64(\(timezoneData))"
@@ -266,7 +266,7 @@ public indirect enum ClickHouseTypeName {
             return "DateTime"
         case .dateTime64(let precisionOuter):
             guard case let .dateTime64Precision(precision, timezoneData) = precisionOuter else {
-                fatalError("dateTime64 should have dateTime64precision-enum for column-metadata, not\(precisionOuter)")
+                fatalError("dateTime64 should have dateTime64precision-enum for column-metadata, not \(precisionOuter)")
             }
             if let timezoneData = timezoneData {
                 return "DateTime64(\(precision), \(timezoneData))"
@@ -286,7 +286,7 @@ public indirect enum ClickHouseTypeName {
             return "Enum16(\(hm))"
         case .enum8(let mappingOuter):
             guard case let .enum8Map(mapping) = mappingOuter else {
-                fatalError("enum8 should have enum8Map-enum for column-metadata, not\(mappingOuter)")
+                fatalError("enum8 should have enum8Map-enum for column-metadata, not \(mappingOuter)")
             }
             // mapping.map({
             //     "'\($0.key)'=\($0.value)"
@@ -556,10 +556,10 @@ public struct ClickHouseDate: ClickHouseDataType, CustomStringConvertible {
 /// When reading, all dates get coerced into the date-range 1900-01-01 00:00:00 to 2299-12-31 23:59:59
 /// as ClickHouse does so too when outputting the DateTime64 in String-form
 public struct ClickHouseDateTime64: ClickHouseDataType, CustomStringConvertible {
-    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, columnMetadata: ClickHouseColumnMetadata?) -> [ClickHouseDateTime64]? {
-        guard let columnMetadata = columnMetadata,
+    public static func readFrom(buffer: inout ByteBuffer, numRows: Int, columnMetadata columnMetadataOuter: ClickHouseColumnMetadata?) -> [ClickHouseDateTime64]? {
+        guard let columnMetadata = columnMetadataOuter,
         case let .dateTime64Precision(precision, _) = columnMetadata else {
-            fatalError("dateTime64 should have dateTime64precision-enum for column-metadata, not \(String(describing: columnMetadata))")
+            fatalError("dateTime64 should have dateTime64precision-enum for column-metadata, not \(String(describing: columnMetadataOuter))")
         }
         guard let intergerArray: [Int64] = buffer.readIntegerArray(numRows: numRows) else {
             return nil
@@ -581,9 +581,9 @@ public struct ClickHouseDateTime64: ClickHouseDataType, CustomStringConvertible 
         return .init(date: .init(timeIntervalSince1970: 0))
     }
 
-    public static func writeTo(buffer: inout ByteBuffer, array: [ClickHouseDateTime64], columnMetadata: ClickHouseColumnMetadata?) {
-        guard let columnMetadata = columnMetadata, case let .dateTime64Precision(precision, _) = columnMetadata else {
-            fatalError("dateTime64 should have dateTime64precision-enum for column-metadata, not\(String(describing: columnMetadata))")
+    public static func writeTo(buffer: inout ByteBuffer, array: [ClickHouseDateTime64], columnMetadata columnMetadataOuter: ClickHouseColumnMetadata?) {
+        guard let columnMetadata = columnMetadataOuter, case let .dateTime64Precision(precision, _) = columnMetadata else {
+            fatalError("dateTime64 should have dateTime64precision-enum for column-metadata, not \(String(describing: columnMetadataOuter))")
         }
         let intergerArray = array.map({
             Int64($0.date.timeIntervalSince1970 * pow(10.0, Double(precision)))

--- a/Sources/ClickHouseNIO/ClickHouseArray.swift
+++ b/Sources/ClickHouseNIO/ClickHouseArray.swift
@@ -255,26 +255,26 @@ public indirect enum ClickHouseTypeName {
             return "Date"
         case .date32:
             return "Date32"
-        case .dateTime(let timezoneData):
-            guard case let .dateTimeTimeZone(timezoneData) = timezoneData else {
-                fatalError("dateTime should have dateTimeTimeZone-enum for column-metadata, not\(timezoneData)")
+        case .dateTime(let timezoneDataOuter):
+            guard case let .dateTimeTimeZone(timezoneData) = timezoneDataOuter else {
+                fatalError("dateTime should have dateTimeTimeZone-enum for column-metadata, not\(timezoneDataOuter)")
             }
             if let timezoneData = timezoneData {
                 return "DateTime64(\(timezoneData))"
 
             }
             return "DateTime"
-        case .dateTime64(let precision):
-            guard case let .dateTime64Precision(precision, timezoneData) = precision else {
-                fatalError("dateTime64 should have dateTime64precision-enum for column-metadata, not\(precision)")
+        case .dateTime64(let precisionOuter):
+            guard case let .dateTime64Precision(precision, timezoneData) = precisionOuter else {
+                fatalError("dateTime64 should have dateTime64precision-enum for column-metadata, not\(precisionOuter)")
             }
             if let timezoneData = timezoneData {
                 return "DateTime64(\(precision), \(timezoneData))"
             }
             return "DateTime64(\(precision))"
-        case .enum16(let mapping):
-            guard case let .enum16Map(mapping) = mapping else {
-                fatalError("enum16 should have enum16Map-enum for column-metadata, not \(mapping)")
+        case .enum16(let mappingOuter):
+            guard case let .enum16Map(mapping) = mappingOuter else {
+                fatalError("enum16 should have enum16Map-enum for column-metadata, not \(mappingOuter)")
             }
             let hm =             mapping.map({
                 "'\($0.key)'=\($0.value)"
@@ -284,9 +284,9 @@ public indirect enum ClickHouseTypeName {
             //     .replacingOccurrences(of: "' : ", with: "' = ")
             //     .dropLast()
             return "Enum16(\(hm))"
-        case .enum8(let mapping):
-            guard case let .enum8Map(mapping) = mapping else {
-                fatalError("enum8 should have enum8Map-enum for column-metadata, not\(mapping)")
+        case .enum8(let mappingOuter):
+            guard case let .enum8Map(mapping) = mappingOuter else {
+                fatalError("enum8 should have enum8Map-enum for column-metadata, not\(mappingOuter)")
             }
             // mapping.map({
             //     "'\($0.key)'=\($0.value)"

--- a/Sources/ClickHouseNIO/Messages/DataMessage.swift
+++ b/Sources/ClickHouseNIO/Messages/DataMessage.swift
@@ -103,7 +103,7 @@ struct DataMessage {
             guard let typeEnum = ClickHouseTypeName(type) else {
                 fatalError("Unknown type \(type)")
             }
-            guard let values = typeEnum.primitiveType.readFrom(buffer: &buffer, numRows: Int(numRows), fixedLength: typeEnum.fixedLength) else {
+            guard let values = typeEnum.primitiveType.readFrom(buffer: &buffer, numRows: Int(numRows), columnMetadata: typeEnum.columnMetadata) else {
                 return nil // need more data
             }
             //print("Column: \(name), Type: \(type)")


### PR DESCRIPTION
Support for:
1. Date
2. Date32 (can't be tested in tests, as the server for testing doesn't support this type)
3. DateTime
4. DateTime64
5. Enum8 & Enum16
6. Bool (similiar to Date32, gets treated as Int8)
7. Array (without nesting of either nullables or arrays)
Would require some minor rewrites in ClickHouseVapor, as I had to add more stuff with the column-metadata.
The date types are distinct from the Swift-Date-Type, and I don't know a way to bridge the Enums to Swift-Enums, so they're just Structs containing a String