### PR TITLE
fix: Sendable warnings

### DIFF
--- a/Sources/ClickHouseNIO/ChannelHandler.swift
+++ b/Sources/ClickHouseNIO/ChannelHandler.swift
@@ -9,7 +9,7 @@ import Foundation
 import Logging
 import NIO
 
-enum ClickHouseCommand {
+enum ClickHouseCommand: Sendable {
     case clientConnect(database: String, user: String, password: String)
     case query(sql: String)
     case command(sql: String)
@@ -17,7 +17,7 @@ enum ClickHouseCommand {
     case ping
 }
 
-enum ClickHouseResult {
+enum ClickHouseResult: Sendable {
     case serverInfo(ServerInfo)
     case error(ExceptionMessage)
     case result(ClickHouseQueryResult)
@@ -25,7 +25,7 @@ enum ClickHouseResult {
     case pong
 }
 
-public struct ClickHouseQueryResult {
+public struct ClickHouseQueryResult: Sendable {
     public let columns: [ClickHouseColumn]
 
     /// ClickHouse transmits multiple DataMessages for each query. Usually the first has all columns, but no data. Here we merge them together.

--- a/Sources/ClickHouseNIO/ClickHouseArray.swift
+++ b/Sources/ClickHouseNIO/ClickHouseArray.swift
@@ -8,7 +8,7 @@
 import Foundation
 import NIO
 
-public struct ClickHouseColumn {
+public struct ClickHouseColumn: Sendable {
     public let name: String
     public let values: ClickHouseDataTypeArray
 
@@ -24,7 +24,7 @@ public struct ClickHouseColumn {
     }
 }
 
-public protocol ClickHouseDataTypeArray {
+public protocol ClickHouseDataTypeArray: Sendable {
     var count: Int { get }
 
     func merge(with: [ClickHouseDataTypeArray]) throws -> ClickHouseDataTypeArray
@@ -567,7 +567,7 @@ public struct ClickHouseDate: ClickHouseDataType, CustomStringConvertible {
         return .date
     }
 
-    public var date: Date
+    public let date: Date
 
     public var description: String {
         "\(date)"
@@ -617,7 +617,7 @@ public struct ClickHouseDateTime64: ClickHouseDataType, CustomStringConvertible 
         return .dateTime64(columnMetadata!)
     }
 
-    public var date: Date
+    public let date: Date
 
     public init(_ exact: Date) {
         self.date = exact
@@ -659,7 +659,7 @@ public struct ClickHouseDateTime: ClickHouseDataType, CustomStringConvertible {
         return .dateTime(.dateTimeTimeZone(nil))
     }
 
-    public var date: Date
+    public let date: Date
 
     public init(_ exact: Date) {
         self.date = exact
@@ -677,7 +677,8 @@ public struct ClickHouseDateTime: ClickHouseDataType, CustomStringConvertible {
 /// Struct for an Enum based on an Int8, only has the word-field which is a String
 /// and the string representation of the enum, it doesn't know the corresponding Int8
 public struct ClickHouseEnum8: ClickHouseDataType, CustomStringConvertible {
-    public var word: String
+    public let word: String
+
     public static func readFrom(buffer: inout ByteBuffer, numRows: Int, columnMetadata: ClickHouseColumnMetadata?) -> [Self]? {
         guard case let .enum8Map(mapping) = columnMetadata! else {
             fatalError("enum8 should have enum8Map-enum for column-metadata, not \(String(describing: columnMetadata))")
@@ -715,8 +716,8 @@ public struct ClickHouseEnum8: ClickHouseDataType, CustomStringConvertible {
 }
 /// Struct for an Enum based on an Int16, only has the word-field which is a String
 /// and the string representation of the enum, it doesn't know the corresponding Int16
-public struct ClickHouseEnum16: ClickHouseDataType, CustomStringConvertible {
-    public var word: String
+public struct ClickHouseEnum16: ClickHouseDataType, CustomStringConvertible, Sendable {
+    public let word: String
 
     public static func readFrom(buffer: inout ByteBuffer, numRows: Int, columnMetadata: ClickHouseColumnMetadata?) -> [Self]? {
         guard case let .enum16Map(mapping) = columnMetadata! else {

--- a/Sources/ClickHouseNIO/Connection.swift
+++ b/Sources/ClickHouseNIO/Connection.swift
@@ -5,7 +5,7 @@ import NIOSSL
 @_exported import struct NIO.TimeAmount
 @_exported import struct NIOSSL.TLSConfiguration
 
-public struct ClickHouseConfiguration {
+public struct ClickHouseConfiguration: Sendable {
     public let serverAddresses: SocketAddress
     public let user: String
     public let password: String
@@ -63,7 +63,7 @@ public class ClickHouseConnection {
     static let DBMS_VERSION_MAJOR: UInt64 = 1
     static let DBMS_VERSION_MINOR: UInt64 = 1
     static let REVISION: UInt64           = 54126
-    public static var defaultPort = 9000
+    public static let defaultPort = 9000
 
     internal let channel: Channel
 


### PR DESCRIPTION
Sendable warnings of things which are definitely `Sendable`. This also includes some minor breaking changes as for instance in `ClickHouseDate` the property `date` is no longer mutable. The changes don't affect `ClickHouseVapor` as far as i can see/test.