### PR TITLE
fix: unbounded capacity growth in ByteBuffer write helpers

### DIFF
--- a/Sources/ClickHouseNIO/ByteBufferExtensions.swift
+++ b/Sources/ClickHouseNIO/ByteBufferExtensions.swift
@@ -57,14 +57,14 @@ extension ByteBuffer {
     mutating func writeClickHouseStrings(_ strings: [String]) {
         let stringLen = strings.reduce(0, { $0 + $1.count })
         let offsetLen = strings.count * MemoryLayout<Int>.size
-        reserveCapacity(writableBytes + stringLen + offsetLen)
+        reserveCapacity(writerIndex + stringLen + offsetLen)
         for string in strings {
             writeClickHouseString(string)
         }
     }
 
     mutating func writeClickHouseFixedStrings(_ strings: [String], length: Int) {
-        reserveCapacity(writableBytes + length * strings.count)
+        reserveCapacity(writerIndex + length * strings.count)
         for string in strings {
             writeClickHouseFixedString(string, length: length)
         }
@@ -206,14 +206,14 @@ extension ByteBuffer {
     }
 
     mutating func writeIntegerArray<T: FixedWidthInteger>(_ array: [T]) {
-        reserveCapacity(array.count * MemoryLayout<T>.size + writableBytes)
+        reserveCapacity(writerIndex + array.count * MemoryLayout<T>.size)
         for element in array {
             writeInteger(element, endianness: .little)
         }
     }
 
     mutating func writeOptionalIntegerArray<T: FixedWidthInteger>(_ array: [T?]) {
-        reserveCapacity(array.count * (MemoryLayout<T>.size + 1) + writableBytes)
+        reserveCapacity(writerIndex + array.count * (MemoryLayout<T>.size + 1))
         // Frist write one array with 0/1 for nullable, then data
         for element in array {
             if element == nil {
@@ -233,7 +233,7 @@ extension ByteBuffer {
 
     /// Write UUID array for clickhouse
     mutating func writeUuidArray(_ array: [UUID], endianness: Endianness = .big) {
-        reserveCapacity(array.count * MemoryLayout<UUID>.size + writableBytes)
+        reserveCapacity(writerIndex + array.count * MemoryLayout<UUID>.size)
         for element in array {
             switch endianness {
             case .big:

--- a/Sources/ClickHouseNIO/ClickHouseArray.swift
+++ b/Sources/ClickHouseNIO/ClickHouseArray.swift
@@ -1061,7 +1061,7 @@ extension Optional: ClickHouseDataType where Wrapped: ClickHouseDataType {
     }
 
     public static func writeTo(buffer: inout ByteBuffer, array: [Wrapped?], columnMetadata: ClickHouseColumnMetadata?) {
-        buffer.reserveCapacity(array.count * (1) + buffer.writableBytes)
+        buffer.reserveCapacity(buffer.writerIndex + array.count)
         // Frist write one array with 0/1 for nullable, then data
         for element in array {
             if element == nil {

--- a/Tests/ClickHouseNIOTests/ByteBufferExtensionsTests.swift
+++ b/Tests/ClickHouseNIOTests/ByteBufferExtensionsTests.swift
@@ -1,0 +1,104 @@
+import NIO
+import XCTest
+
+@testable import ClickHouseNIO
+
+/// Regression tests for a capacity-leak in the `ByteBuffer` write helpers.
+///
+/// The write helpers used to call `reserveCapacity(N + writableBytes)`, where
+/// `writableBytes == capacity - writerIndex`. `ByteBuffer.reserveCapacity`
+/// takes a *total* capacity, not "additional" bytes, so after
+/// `MessageToByteEncoder.clear()` (which resets `writerIndex` to 0 but keeps
+/// capacity), every call became `reserveCapacity(N + currentCapacity)` and the
+/// buffer doubled forever. Over a long-lived pooled connection doing many
+/// small inserts, this manifested as a multi-GB memory leak with no change in
+/// payload size.
+///
+/// The correct form is `reserveCapacity(writerIndex + N)`, which asks for the
+/// total capacity needed after writing `N` more bytes starting from the
+/// current writer position.
+final class ByteBufferExtensionsTests: XCTestCase {
+    /// Simulates the `MessageToByteEncoder` reuse pattern: the same buffer is
+    /// cleared between encodes and written to again. If the reserve-capacity
+    /// formula is wrong, capacity doubles on every iteration even when the
+    /// payload size is constant.
+    func testWriteIntegerArrayDoesNotDoubleCapacityAcrossClears() {
+        var buf = ByteBufferAllocator().buffer(capacity: 256)
+        let array: [UInt64] = [1, 2, 3, 4, 5, 6]
+
+        for _ in 0..<20 {
+            buf.clear()
+            buf.writeIntegerArray(array)
+        }
+
+        // 20 iterations of a 48-byte write should not grow the buffer beyond
+        // a small constant. The buggy form grew capacity to ~256 MB at 20
+        // iterations (each call ~doubled it), so 4 KB is a comfortable ceiling
+        // that still catches any regression to exponential growth.
+        XCTAssertLessThanOrEqual(
+            buf.capacity,
+            4096,
+            "ByteBuffer capacity grew unexpectedly — writeIntegerArray is leaking capacity across clears"
+        )
+    }
+
+    func testWriteOptionalIntegerArrayDoesNotDoubleCapacityAcrossClears() {
+        var buf = ByteBufferAllocator().buffer(capacity: 256)
+        let array: [UInt64?] = [1, nil, 3, nil, 5, 6]
+
+        for _ in 0..<20 {
+            buf.clear()
+            buf.writeOptionalIntegerArray(array)
+        }
+
+        XCTAssertLessThanOrEqual(buf.capacity, 4096)
+    }
+
+    func testWriteClickHouseStringsDoesNotDoubleCapacityAcrossClears() {
+        var buf = ByteBufferAllocator().buffer(capacity: 256)
+        let strings = ["gateway", "exporter", "auth", "billing", "cdn", "chat"]
+
+        for _ in 0..<20 {
+            buf.clear()
+            buf.writeClickHouseStrings(strings)
+        }
+
+        XCTAssertLessThanOrEqual(buf.capacity, 4096)
+    }
+
+    func testWriteClickHouseFixedStringsDoesNotDoubleCapacityAcrossClears() {
+        var buf = ByteBufferAllocator().buffer(capacity: 256)
+        let strings = ["aaaaaaaa", "bbbbbbbb", "cccccccc", "dddddddd"]
+
+        for _ in 0..<20 {
+            buf.clear()
+            buf.writeClickHouseFixedStrings(strings, length: 8)
+        }
+
+        XCTAssertLessThanOrEqual(buf.capacity, 4096)
+    }
+
+    func testWriteUuidArrayDoesNotDoubleCapacityAcrossClears() {
+        var buf = ByteBufferAllocator().buffer(capacity: 256)
+        let uuids = (0..<4).map { _ in UUID() }
+
+        for _ in 0..<20 {
+            buf.clear()
+            buf.writeUuidArray(uuids)
+        }
+
+        XCTAssertLessThanOrEqual(buf.capacity, 4096)
+    }
+
+    /// Sanity: the write helpers still produce the same bytes they did before
+    /// — the fix is a pure capacity-math change, it must not touch the wire
+    /// format.
+    func testWriteIntegerArrayPayloadUnchanged() {
+        var buf = ByteBufferAllocator().buffer(capacity: 256)
+        buf.writeIntegerArray([UInt64(1), UInt64(2), UInt64(3)])
+        XCTAssertEqual(buf.readableBytes, 3 * MemoryLayout<UInt64>.size)
+        XCTAssertEqual(buf.readInteger(endianness: .little, as: UInt64.self), 1)
+        XCTAssertEqual(buf.readInteger(endianness: .little, as: UInt64.self), 2)
+        XCTAssertEqual(buf.readInteger(endianness: .little, as: UInt64.self), 3)
+    }
+}


### PR DESCRIPTION
## Summary

Six write helpers in `ByteBufferExtensions.swift` and `ClickHouseArray.swift` pass the wrong value to `ByteBuffer.reserveCapacity(_:)`, causing the encoder's buffer to double in capacity on every insert against a long-lived pooled connection even when the payload is constant.

`ByteBuffer.reserveCapacity(_ minimumCapacity:)` takes a **total** capacity, not additional bytes. The helpers do:

```swift
reserveCapacity(N + writableBytes)
```

where `writableBytes == capacity - writerIndex`. `MessageToByteEncoder.write(...)` calls `buffer.clear()` between encodes, which resets `writerIndex` to `0` but keeps the existing capacity. So after `clear()`:

```
writableBytes == capacity
reserveCapacity(N + writableBytes) == reserveCapacity(N + capacity)
                                    → grows capacity by at least N every call
```

Over a long-lived pooled `ClickHouseConnection` doing repeated inserts, the encoder's internal `ByteBuffer` grows without bound. The data is still written correctly — the wire format is unaffected — but the allocated-but-never-freed capacity keeps climbing.

## Reproduction

A minimal repro that exercises only `swift-nio`'s `ByteBuffer` and the exact buggy line pattern:

```swift
var buf = ByteBufferAllocator().buffer(capacity: 256)
let array: [UInt64] = [1, 2, 3, 4, 5, 6]   // 48 bytes

for i in 1...20 {
    buf.clear()
    // Same line as ByteBufferExtensions.swift:209
    buf.reserveCapacity(array.count * MemoryLayout<UInt64>.size + buf.writableBytes)
    for element in array { buf.writeInteger(element, endianness: .little) }
    print("iter=\(i) capacity=\(buf.capacity)")
}
```

Output:

```
iter=1  capacity=512
iter=2  capacity=1024
iter=3  capacity=2048
iter=10 capacity=262144
iter=15 capacity=8388608
iter=20 capacity=268435456      ← 256 MB for the same 48-byte write
```

Replacing that single line with `reserveCapacity(buf.writerIndex + array.count * MemoryLayout<UInt64>.size)` keeps capacity at 256 bytes for all 20 iterations.

The leak also reproduces end-to-end via `ClickHouseVapor.insert(on:)` with a model equivalent to our production `metrics_histogram` schema — 100 inserts of 8 rows each grew process RSS from 15 MB to 50 MB on macOS (growth accelerating at the tail). On Linux with jemalloc the same pattern drove process RSS past 3 GB within minutes against a stable insert rate, taking down our exporter container.

## Fix

Replace the six call sites with `reserveCapacity(writerIndex + N)`, which is the total capacity needed after writing `N` more bytes starting from the current writer position. When `writerIndex == 0` this is just `N`, and `reserveCapacity` correctly no-ops whenever that fits in the existing capacity — exactly the behavior a reused encoder buffer wants.

Six sites:

- `ByteBufferExtensions.writeClickHouseStrings`
- `ByteBufferExtensions.writeClickHouseFixedStrings`
- `ByteBufferExtensions.writeIntegerArray`
- `ByteBufferExtensions.writeOptionalIntegerArray`
- `ByteBufferExtensions.writeUuidArray`
- `ClickHouseArray.Optional.writeTo`

## Tests

Added `ByteBufferExtensionsTests` with one capacity-regression test per helper and a wire-format sanity check.

- The regression tests clear and rewrite the same buffer 20 times and assert capacity stays under 4 KB. Without this fix, five of them fail with `capacity = 268435456` (256 MB) — exactly matching the repro above.
- The wire-format sanity test confirms `writeIntegerArray` still produces byte-identical output. This is a pure capacity-math change, not a format change.

Verified locally:

```
Executed 6 tests, with 0 failures (0 unexpected) in 0.003 seconds
```

and with the fix reverted:

```
Executed 6 tests, with 5 failures (0 unexpected) in 0.132 seconds
```

## Test plan

- [x] `swift test --filter ByteBufferExtensionsTests` passes with the fix
- [x] Same tests fail on the unpatched helpers (verified by stashing only the source change)
- [x] Existing `ClickhouseNIOTests` still compile (unchanged wire format)
- [x] End-to-end repro against a local ClickHouse server via `ClickHouseVapor` no longer shows linear RSS growth after the fix